### PR TITLE
ocamlbuildcpp-dev.0.2 - via opam-publish

### DIFF
--- a/packages/ocamlbuildcpp-dev/ocamlbuildcpp-dev.0.2/descr
+++ b/packages/ocamlbuildcpp-dev/ocamlbuildcpp-dev.0.2/descr
@@ -1,0 +1,3 @@
+An ocamlbuild plugin to compile C++ 
+
+An ocamlbuild plugin to compile C++. Try to support G++, Clang++ and VC++.

--- a/packages/ocamlbuildcpp-dev/ocamlbuildcpp-dev.0.2/opam
+++ b/packages/ocamlbuildcpp-dev/ocamlbuildcpp-dev.0.2/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "Joe Dralliam <jdralliam@gmail.com>"
+authors: "Joe Dralliam <jdralliam@gmail.com>"
+homepage: "https://github.com/JoeDralliam/OcamlbuildCpp"
+bug-reports: "https://github.com/JoeDralliam/OcamlbuildCpp/issues"
+dev-repo: "git://github.com/JoeDralliam/OcamlbuildCpp"
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/ocamlbuildcpp-dev/ocamlbuildcpp-dev.0.2/url
+++ b/packages/ocamlbuildcpp-dev/ocamlbuildcpp-dev.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/JoeDralliam/OcamlbuildCpp/archive/v0.2.tar.gz"
+checksum: "fb800b41ebc4a036362a12c6f17702e3"


### PR DESCRIPTION
An ocamlbuild plugin to compile C++ 

An ocamlbuild plugin to compile C++. Try to support G++, Clang++ and VC++.

---
- Homepage: https://github.com/JoeDralliam/OcamlbuildCpp
- Source repo: git://github.com/JoeDralliam/OcamlbuildCpp
- Bug tracker: https://github.com/JoeDralliam/OcamlbuildCpp/issues

---

Pull-request generated by opam-publish v0.3.1
