### PR TITLE
ocsfml-dev.2.3 - via opam-publish

### DIFF
--- a/packages/ocsfml-dev/ocsfml-dev.2.3/descr
+++ b/packages/ocsfml-dev/ocsfml-dev.2.3/descr
@@ -1,0 +1,3 @@
+An ocaml port of the SFML library
+
+An ocaml port of the SFML library.

--- a/packages/ocsfml-dev/ocsfml-dev.2.3/opam
+++ b/packages/ocsfml-dev/ocsfml-dev.2.3/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "Joe Dralliam <jdralliam@gmail.com>"
+authors: "Joe Dralliam <jdralliam@gmail.com>"
+homepage: "https://github.com/JoeDralliam/Ocsfml"
+bug-reports: "https://github.com/JoeDralliam/Ocsfml/issues"
+dev-repo: "git://github.com/JoeDralliam/Ocsfml"
+build: [make]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuildcpp-dev" {build}
+]

--- a/packages/ocsfml-dev/ocsfml-dev.2.3/url
+++ b/packages/ocsfml-dev/ocsfml-dev.2.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/JoeDralliam/Ocsfml/archive/2.3.tar.gz"
+checksum: "b0d25774a0f567d1ec956370947ee2ac"


### PR DESCRIPTION
An ocaml port of the SFML library

An ocaml port of the SFML library.

---
- Homepage: https://github.com/JoeDralliam/Ocsfml
- Source repo: git://github.com/JoeDralliam/Ocsfml
- Bug tracker: https://github.com/JoeDralliam/Ocsfml/issues

---

Pull-request generated by opam-publish v0.3.1
