### PR TITLE
ocsfml-dev.2.3 - via opam-publish

### DIFF
--- a/packages/ocsfml-dev/ocsfml-dev.2.3/url
+++ b/packages/ocsfml-dev/ocsfml-dev.2.3/url
@@ -1,2 +1,2 @@
-http: "https://github.com/JoeDralliam/Ocsfml/archive/2.3.tar.gz"
-checksum: "b0d25774a0f567d1ec956370947ee2ac"
+http: "https://github.com/JoeDralliam/Ocsfml/archive/2.3b.tar.gz"
+checksum: "87d539d67fe7e16dc43bf225dff3d83c"


### PR DESCRIPTION
An ocaml port of the SFML library

An ocaml port of the SFML library.

---
- Homepage: https://github.com/JoeDralliam/Ocsfml
- Source repo: git://github.com/JoeDralliam/Ocsfml
- Bug tracker: https://github.com/JoeDralliam/Ocsfml/issues

---

Pull-request generated by opam-publish v0.3.1
